### PR TITLE
Ensure spawn process runs so that test fails

### DIFF
--- a/ping_pong/test/ping_pong_test.exs
+++ b/ping_pong/test/ping_pong_test.exs
@@ -68,6 +68,8 @@ defmodule PingPongTest do
       GenServer.call({Consumer, n1}, :crash)
     end)
 
+    :erlang.yield()
+
     for n <- nodes do
       eventually(fn ->
         assert Consumer.count_for_node({Consumer, n}, Node.self()) == 2


### PR DESCRIPTION
While going through the Ping Pong example for problem 3, the test was passing before the spawned process was able to run.  We originally added `Process.sleep()` to give the spawned call time to run.  decided `:erlang.yield()` was cleaner.